### PR TITLE
Add code of conduct announcements to event protocol

### DIFF
--- a/event_protocol.md
+++ b/event_protocol.md
@@ -5,12 +5,19 @@ directly by Hack Club.
 
 ## Preparation
 
-- [ ] Link to our [Code of Conduct][code_of_conduct] in marketing materials
+- [ ] Link to our [code of conduct][code_of_conduct] in marketing materials
 
-[code_of_conduct]: https://github.com/hackclub/hackclub/blob/master/CONDUCT.md
 
 ## Day Of
 
 - [ ] Place a sign on the entrance of the venue with the name of the event and
   the phone number of one of the organizers (in case people who arrive late need
   to get in or otherwise reach an organizer)
+- [ ] Designate someone to handle code of conduct related issues
+- [ ] Announce that we have a [code of conduct][code_of_conduct] at the event
+      and explain what that means for the participants
+- [ ] Announce that if anyone ever feels uncomfortable during the course of the
+      event, they should speak to the person designated to handle code of
+      conduct related issues
+
+[code_of_conduct]: https://github.com/hackclub/hackclub/blob/master/CONDUCT.md


### PR DESCRIPTION
This adds making code of conduct related announcements to our events protocol.

[See here](https://github.com/hackclub/meta/pull/454/files#diff-4fd6147d0844f75ca77f0067f965f4c8R13) for the meeting notes where we discussed doing this.