### PR TITLE
Remove alt attribute from images in markdown styleguide

### DIFF
--- a/styleguides/markdown.md
+++ b/styleguides/markdown.md
@@ -26,7 +26,6 @@ readable, consistent files using Markdown.
 - Force a linebreak by ending a line with two spaces, no more.
 - Quote marks (`>`) should be on all quoted lines, not just the beginning of a
   quote.
-- Provide alternate access to media. Include `alt` attributes in all images.
 
 ## Headings
 


### PR DESCRIPTION
This is a result of [this conversation](https://github.com/hackclub/meta/pull/437#issuecomment-178964449)

\cc @MaxWofford