### PR TITLE
Update sign-up instructions to reflect reality

### DIFF
--- a/processes/pagerduty_process.md
+++ b/processes/pagerduty_process.md
@@ -4,12 +4,7 @@ PagerDuty is Hack Club's on-call system and issue escalation policy. It works by
 
 ## Create An Account
 
-The first step is to create a PagerDuty account. You can read the full instructions [here][pagerduty_create_account].
-Make sure to install the app for your phone and have notifications all set up before going to the next step.
-
-Join the team by asking a staff member with a PagerDuty account to invite you to be in the PagerDuty team.
-
-[pagerduty_create_account]: https://support.pagerduty.com/hc/en-us/articles/202828690-PagerDuty-Quick-Start-Guide#userprofile
+The first step is to get an invite to PagerDuty. Get in touch with a staff member that already has an account and ask them to send an invite.
 
 ## On-Call
 


### PR DESCRIPTION
This PR updates our PagerDuty sign-up instructions to reflect reality – you must get an invite, you can't create an account and then later be invited.